### PR TITLE
Ability to use vmware as provider

### DIFF
--- a/example/Vagrantfile
+++ b/example/Vagrantfile
@@ -8,11 +8,12 @@ unless Vagrant.has_plugin?("vagrant-docker-compose")
 end
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "hashicorp/precise64"
 
   config.vm.network(:forwarded_port, guest: 8080, host: 8080)
 
   config.vm.provision :shell, inline: "apt-get update"
+  config.vm.provision :shell, inline: "apt-get -q -y install apt-transport-https"
   config.vm.provision :docker
   config.vm.provision :docker_compose, yml: "/vagrant/docker-compose.yml", rebuild: true, project_name: "myproject", run: "always"
 end


### PR DESCRIPTION
The "ubuntu/trusty64" box does not have a version for vmware so the
example did not work if vmware was the provider. These changes should
allow the example to work under any provider.